### PR TITLE
Add 'refresh' property to params

### DIFF
--- a/update.js
+++ b/update.js
@@ -30,6 +30,7 @@ module.exports = function(RED) {
         index: documentIndex,
         type: documentType,
         id: documentId,
+        refresh: msg.refresh,
         body: {
           doc: msg.payload
         }


### PR DESCRIPTION
If true then refresh the effected shards to make this operation visible to search, if wait_for then wait for a refresh to make this operation visible to search, if false (the default) then do nothing with refreshes.

Options
"true"
"false"
"wait_for"
""