### PR TITLE
Add 'refresh' property to params in delete.js

### DIFF
--- a/delete.js
+++ b/delete.js
@@ -30,7 +30,8 @@ module.exports = function(RED) {
       var params = {
         index: documentIndex,
         type: documentType,
-        id: documentId
+        id: documentId,
+        refresh: msg.refresh
       }
 
       client.delete(params).then(function (resp) {


### PR DESCRIPTION
If true then refresh the effected shards to make this operation visible to search, if wait_for then wait for a refresh to make this operation visible to search, if false (the default) then do nothing with refreshes.

Options
"true"
"false"
"wait_for"
""