### PR TITLE
Update create.js #10

### DIFF
--- a/create.js
+++ b/create.js
@@ -30,7 +30,7 @@ module.exports = function(RED) {
         body: msg.payload
       }
 
-      client.create(params).then(function (resp) {
+      client.index(params).then(function (resp) {
         msg.payload = resp;
         node.send(msg);
       }, function (err) {


### PR DESCRIPTION
Use `index` instead of `create` for it forces a ID created by the code. If using `index`, it will create a corresponding ID for the document.